### PR TITLE
Fix issue that any attribute would suppress CS8618

### DIFF
--- a/src/CSharpExtensions.Analyzers3/NotNullablePropertyInitializationDiagnosticSuppressor.cs
+++ b/src/CSharpExtensions.Analyzers3/NotNullablePropertyInitializationDiagnosticSuppressor.cs
@@ -65,7 +65,7 @@ namespace CSharpExtensions.Analyzers3
                 }
             }
 
-            return true;
+            return false;
         }
     }
 }


### PR DESCRIPTION
The issue is that if we put any attribute to any class or field of the
class, CS8618 would be suppressed completely.

We want to suppress CS8618 only when we put InitRequired or InitOnly
attributes to class/field, not just any attribute at all.