### PR TITLE
Upgrade packages to minimize the size of dependency graph

### DIFF
--- a/src/CSharpExtensions.Analyzers.Test/CSharpExtensions.Analyzers.Test.csproj
+++ b/src/CSharpExtensions.Analyzers.Test/CSharpExtensions.Analyzers.Test.csproj
@@ -6,18 +6,18 @@
 
   <ItemGroup>
     <PackageReference Include="Appveyor.TestLogger" Version="2.0.0" />
-    <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="3.3.0">
+    <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="3.3.2">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.CodeAnalysis.Common" Version="3.7.0" />
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="3.7.0" />
-    <PackageReference Include="Microsoft.CodeAnalysis.Features" Version="3.7.0" PrivateAssets="all" />
-    <PackageReference Include="Microsoft.CodeAnalysis.VisualBasic.Workspaces" Version="3.7.0" />
-    <PackageReference Include="Microsoft.CodeAnalysis.Workspaces.Common" Version="3.7.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.5.0" />
-    <PackageReference Include="NUnit" Version="3.12.0" />
-    <PackageReference Include="NUnit3TestAdapter" Version="3.16.1">
+    <PackageReference Include="Microsoft.CodeAnalysis.Common" Version="3.8.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="3.8.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.Features" Version="3.8.0" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.CodeAnalysis.VisualBasic.Workspaces" Version="3.8.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.Workspaces.Common" Version="3.8.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.6.1" />
+    <PackageReference Include="NUnit" Version="3.13.0" />
+    <PackageReference Include="NUnit3TestAdapter" Version="4.0.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>


### PR DESCRIPTION
Hi@cezarypiatek, I found an issue in the CSharpExtensions.Analyzers.Test.csproj:

Packages Microsoft.CodeAnalysis.Analyzers v3.3.0, Microsoft.CodeAnalysis.Common v3.7.0, Microsoft.CodeAnalysis.CSharp.Workspaces v3.7.0, Microsoft.CodeAnalysis.Features v3.7.0, Microsoft.CodeAnalysis.VisualBasic.Workspaces v3.7.0, Microsoft.CodeAnalysis.Workspaces.Common v3.7.0, Microsoft.NET.Test.Sdk v16.5.0, NUnit v3.12.0 and NUnit3TestAdapter v3.16.1 transitively introduce 76 dependencies into CSharpExtensions’s dependency graph ([see dependency graph before upgrades](http://202.182.124.107:8000/CSharpExtensions.html)), while Microsoft.CodeAnalysis.Analyzers v3.3.2, Microsoft.CodeAnalysis.CSharp.Workspaces v3.8.0, Microsoft.CodeAnalysis.Common v3.8.0, Microsoft.CodeAnalysis.Features v3.8.0, Microsoft.CodeAnalysis.VisualBasic.Workspaces v3.8.0, Microsoft.CodeAnalysis.Workspaces.Common v3.8.0, Microsoft.NET.Test.Sdk v16.6.1, NUnit v3.13.0 and NUnit3TestAdapter v4.0.0 can only introduce 47 dependencies ([see dependency graph after upgrades](http://202.182.124.107:8000/CSharpExtensions_after.html)).

These upgrades can help project minimize the size of dependency graph.
Hope the PR can help you.

Best regards,
sucrose